### PR TITLE
fix: use a dedicated reducible balance for evm

### DIFF
--- a/frame/assets/src/impl_fungibles.rs
+++ b/frame/assets/src/impl_fungibles.rs
@@ -59,6 +59,16 @@ impl<T: Config<I>, I: 'static> fungibles::Inspect<<T as SystemConfig>::AccountId
 			.unwrap_or(Zero::zero())
 	}
 
+	fn evm_reducible_balance(
+		asset: Self::AssetId,
+		who: &<T as SystemConfig>::AccountId,
+		preservation: Preservation,
+		_: Fortitude,
+	) -> Self::Balance {
+		Pallet::<T, I>::reducible_balance(asset, who, !matches!(preservation, Expendable))
+			.unwrap_or(Zero::zero())
+	}
+
 	fn can_deposit(
 		asset: Self::AssetId,
 		who: &<T as SystemConfig>::AccountId,

--- a/frame/balances/src/impl_fungible.rs
+++ b/frame/balances/src/impl_fungible.rs
@@ -79,19 +79,7 @@ impl<T: Config<I>, I: 'static> fungible::Inspect<T::AccountId> for Pallet<T, I> 
 		if force == Polite {
 			// Frozen balance applies to total. Anything on hold therefore gets discounted from the
 			// limit given by the freezes.
-			untouchable = a.frozen;
-		}
-		// If we want to keep our provider ref..
-		if preservation == Preserve
-			// ..or we don't want the account to die and our provider ref is needed for it to live..
-			|| preservation == Protect && !a.free.is_zero() &&
-			frame_system::Pallet::<T>::providers(who) == 1
-			// ..or we don't care about the account dying but our provider ref is required..
-			|| preservation == Expendable && !a.free.is_zero() &&
-			!frame_system::Pallet::<T>::can_dec_provider(who)
-		{
-			// ..then the ED needed..
-			untouchable = untouchable.max(T::ExistentialDeposit::get());
+			untouchable = a.frozen.saturating_add(a.reserved);
 		}
 		// Liquid balance is what is neither on hold nor frozen/required for provider.
 		a.free.saturating_sub(untouchable)

--- a/frame/balances/src/impl_fungible.rs
+++ b/frame/balances/src/impl_fungible.rs
@@ -74,15 +74,7 @@ impl<T: Config<I>, I: 'static> fungible::Inspect<T::AccountId> for Pallet<T, I> 
 		preservation: Preservation,
 		force: Fortitude,
 	) -> Self::Balance {
-		let a = Self::account(who);
-		let mut untouchable = Zero::zero();
-		if force == Polite {
-			// Frozen balance applies to total. Anything on hold therefore gets discounted from the
-			// limit given by the freezes.
-			untouchable = a.frozen.saturating_add(a.reserved);
-		}
-		// Liquid balance is what is neither on hold nor frozen/required for provider.
-		a.free.saturating_sub(untouchable)
+		Self::account(who).usable()
 	}
 	fn can_deposit(
 		who: &T::AccountId,

--- a/frame/balances/src/impl_fungible.rs
+++ b/frame/balances/src/impl_fungible.rs
@@ -68,17 +68,45 @@ impl<T: Config<I>, I: 'static> fungible::Inspect<T::AccountId> for Pallet<T, I> 
 		// Liquid balance is what is neither on hold nor frozen/required for provider.
 		a.free.saturating_sub(untouchable)
 	}
+
+	fn evm_reducible_balance(
+		who: &T::AccountId,
+		preservation: Preservation,
+		force: Fortitude,
+	) -> Self::Balance {
+		let a = Self::account(who);
+		let mut untouchable = Zero::zero();
+		if force == Polite {
+			// Frozen balance applies to total. Anything on hold therefore gets discounted from the
+			// limit given by the freezes.
+			untouchable = a.frozen;
+		}
+		// If we want to keep our provider ref..
+		if preservation == Preserve
+			// ..or we don't want the account to die and our provider ref is needed for it to live..
+			|| preservation == Protect && !a.free.is_zero() &&
+			frame_system::Pallet::<T>::providers(who) == 1
+			// ..or we don't care about the account dying but our provider ref is required..
+			|| preservation == Expendable && !a.free.is_zero() &&
+			!frame_system::Pallet::<T>::can_dec_provider(who)
+		{
+			// ..then the ED needed..
+			untouchable = untouchable.max(T::ExistentialDeposit::get());
+		}
+		// Liquid balance is what is neither on hold nor frozen/required for provider.
+		a.free.saturating_sub(untouchable)
+	}
 	fn can_deposit(
 		who: &T::AccountId,
 		amount: Self::Balance,
 		provenance: Provenance,
 	) -> DepositConsequence {
 		if amount.is_zero() {
-			return DepositConsequence::Success
+			return DepositConsequence::Success;
 		}
 
 		if provenance == Minted && TotalIssuance::<T, I>::get().checked_add(&amount).is_none() {
-			return DepositConsequence::Overflow
+			return DepositConsequence::Overflow;
 		}
 
 		let account = Self::account(who);
@@ -103,11 +131,11 @@ impl<T: Config<I>, I: 'static> fungible::Inspect<T::AccountId> for Pallet<T, I> 
 		amount: Self::Balance,
 	) -> WithdrawConsequence<Self::Balance> {
 		if amount.is_zero() {
-			return WithdrawConsequence::Success
+			return WithdrawConsequence::Success;
 		}
 
 		if TotalIssuance::<T, I>::get().checked_sub(&amount).is_none() {
-			return WithdrawConsequence::Underflow
+			return WithdrawConsequence::Underflow;
 		}
 
 		let account = Self::account(who);
@@ -118,7 +146,7 @@ impl<T: Config<I>, I: 'static> fungible::Inspect<T::AccountId> for Pallet<T, I> 
 
 		let liquid = Self::reducible_balance(who, Expendable, Polite);
 		if amount > liquid {
-			return WithdrawConsequence::Frozen
+			return WithdrawConsequence::Frozen;
 		}
 
 		// Provider restriction - total account balance cannot be reduced to zero if it cannot
@@ -130,7 +158,7 @@ impl<T: Config<I>, I: 'static> fungible::Inspect<T::AccountId> for Pallet<T, I> 
 			if frame_system::Pallet::<T>::can_dec_provider(who) {
 				WithdrawConsequence::ReducedToZero(new_free_balance)
 			} else {
-				return WithdrawConsequence::WouldDie
+				return WithdrawConsequence::WouldDie;
 			}
 		} else {
 			WithdrawConsequence::Success
@@ -140,7 +168,7 @@ impl<T: Config<I>, I: 'static> fungible::Inspect<T::AccountId> for Pallet<T, I> 
 
 		// Eventual free funds must be no less than the frozen balance.
 		if new_total_balance < account.frozen {
-			return WithdrawConsequence::Frozen
+			return WithdrawConsequence::Frozen;
 		}
 
 		success
@@ -232,11 +260,11 @@ impl<T: Config<I>, I: 'static> fungible::InspectHold<T::AccountId> for Pallet<T,
 	}
 	fn hold_available(reason: &Self::Reason, who: &T::AccountId) -> bool {
 		if frame_system::Pallet::<T>::providers(who) == 0 {
-			return false
+			return false;
 		}
 		let holds = Holds::<T, I>::get(who);
 		if holds.is_full() && !holds.iter().any(|x| &x.id == reason) {
-			return false
+			return false;
 		}
 		true
 	}
@@ -302,7 +330,7 @@ impl<T: Config<I>, I: 'static> fungible::InspectFreeze<T::AccountId> for Pallet<
 impl<T: Config<I>, I: 'static> fungible::MutateFreeze<T::AccountId> for Pallet<T, I> {
 	fn set_freeze(id: &Self::Id, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
 		if amount.is_zero() {
-			return Self::thaw(id, who)
+			return Self::thaw(id, who);
 		}
 		let mut locks = Freezes::<T, I>::get(who);
 		if let Some(i) = locks.iter_mut().find(|x| &x.id == id) {
@@ -317,7 +345,7 @@ impl<T: Config<I>, I: 'static> fungible::MutateFreeze<T::AccountId> for Pallet<T
 
 	fn extend_freeze(id: &Self::Id, who: &T::AccountId, amount: Self::Balance) -> DispatchResult {
 		if amount.is_zero() {
-			return Ok(())
+			return Ok(());
 		}
 		let mut locks = Freezes::<T, I>::get(who);
 		if let Some(i) = locks.iter_mut().find(|x| &x.id == id) {

--- a/frame/nis/src/lib.rs
+++ b/frame/nis/src/lib.rs
@@ -134,6 +134,9 @@ impl<T> FunInspect<T> for NoCounterpart<T> {
 	fn reducible_balance(_: &T, _: Preservation, _: Fortitude) -> u32 {
 		0
 	}
+	fn evm_reducible_balance(_: &T, _: Preservation, _: Fortitude) -> u32 {
+		0
+	}
 	fn can_deposit(_: &T, _: u32, _: Provenance) -> DepositConsequence {
 		DepositConsequence::Success
 	}

--- a/frame/support/src/traits/tokens/fungible/item_of.rs
+++ b/frame/support/src/traits/tokens/fungible/item_of.rs
@@ -63,6 +63,18 @@ impl<
 	) -> Self::Balance {
 		<F as fungibles::Inspect<AccountId>>::reducible_balance(A::get(), who, preservation, force)
 	}
+	fn evm_reducible_balance(
+		who: &AccountId,
+		preservation: Preservation,
+		force: Fortitude,
+	) -> Self::Balance {
+		<F as fungibles::Inspect<AccountId>>::evm_reducible_balance(
+			A::get(),
+			who,
+			preservation,
+			force,
+		)
+	}
 	fn can_deposit(
 		who: &AccountId,
 		amount: Self::Balance,

--- a/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/frame/support/src/traits/tokens/fungible/regular.rs
@@ -89,6 +89,11 @@ pub trait Inspect<AccountId>: Sized {
 		preservation: Preservation,
 		force: Fortitude,
 	) -> Self::Balance;
+	fn evm_reducible_balance(
+		who: &AccountId,
+		preservation: Preservation,
+		force: Fortitude,
+	) -> Self::Balance;
 
 	/// Returns `true` if the balance of `who` may be increased by `amount`.
 	///

--- a/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -93,6 +93,12 @@ pub trait Inspect<AccountId>: Sized {
 		preservation: Preservation,
 		force: Fortitude,
 	) -> Self::Balance;
+	fn evm_reducible_balance(
+		asset: Self::AssetId,
+		who: &AccountId,
+		preservation: Preservation,
+		force: Fortitude,
+	) -> Self::Balance;
 
 	/// Returns `true` if the `asset` balance of `who` may be increased by `amount`.
 	///


### PR DESCRIPTION
## Changes
- Use a dedicated reducible balance method for EVM compatibility
- This change will resolve the inconsistency between the transferrable and EVM balance